### PR TITLE
19619:  Add react 17 and 18 as acceptable peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 	},
 	"license": "MIT",
 	"peerDependencies": {
-		"react": "^16.0.0"
+		"react": "16 || 17 || 18"
 	},
 	"dependencies": {
 		"lodash": "^4.17.21",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -33,6 +33,7 @@ export interface OTSessionProps {
 	eventHandlers?: SessionEventHandlers;
 	onConnect?: () => void;
 	onError?: (error: Error) => void;
+	children?: React.ReactNode;
 }
 
 export interface OTStreamsProps {


### PR DESCRIPTION
There's very little changes in React 18 that affects this repo, the only change is that `children` needs to be explicitly typed. 

I do not have time to update the tests since we would need to replace Enzyme, but I have tested the example app when running React@18 without any issues. 

https://react.dev/blog/2022/03/08/react-18-upgrade-guide#react