### PR TITLE
Add missing `@babel/runtime` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.3.0",
 			"license": "MIT",
 			"dependencies": {
+				"@babel/runtime": "^7.29.7",
 				"lodash": "^4.18.1",
 				"prop-types": "^15.8.1",
 				"react-display-name": "^0.2.0",
@@ -1906,10 +1907,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.27.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
-			"integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
-			"dev": true,
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -10731,10 +10731,9 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.27.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
-			"integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
-			"dev": true
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="
 		},
 		"@babel/template": {
 			"version": "7.29.7",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"react": "16 || 17 || 18"
 	},
 	"dependencies": {
+		"@babel/runtime": "^7.29.7",
 		"lodash": "^4.18.1",
 		"prop-types": "^15.8.1",
 		"react-display-name": "^0.2.0",


### PR DESCRIPTION
Turns out that `@babel/runtime` is an undeclared dependency of this library (introduced via `@babel/plugin-transform-runtime`). Things were only working because a third-party package happened to depend on it.